### PR TITLE
Edited README, fixes #30

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 - [Testing](#testing)
 - [Data Structures](#data-structures)
   - [Maps](#maps)
-- [Elixir Resources](#elixir-resources)
 - [Further Resources](#further-resources)
 
 
@@ -850,14 +849,6 @@ iex> %{animals | name: "Max"}
 **NOTE:** Unlike the function method above, this syntax can only be used to UPDATE
 a current key-value pair inside the map, it cannot add a new key value pair.
 
-## Elixir Resources
-
-+ Crash Course in Elixir: http://elixir-lang.org/crash-course.html
-+ Explanation video of Pattern Matching in Elixir: http://worldwide.chat/
-+ Sign up to: https://elixirweekly.net/ for regular (_relevant_) updates!
-+ List of _way_ more useful resources and sample apps:
-https://github.com/h4cc/awesome-elixir
-
 ## tl;dr
 
 > ***Note***: this is _definately **not**_ a "_reason_" to switch programming
@@ -877,15 +868,16 @@ http://stackoverflow.com/questions/18011784/why-are-there-two-kinds-of-functions
 
 ## Further resources:
 
-- Then if you want to know what's _next_ it's worth watching [What's Ahead for Elixir?](https://youtu.be/A60nxws_iVs) (53 mins)
++ [Crash Course in Elixir](http://elixir-lang.org/crash-course.html)
++ [Explanation video of **Pattern Matching** in Elixir](http://worldwide.chat/)
++ Sign up to: https://elixirweekly.net/ for regular (_relevant_) updates!
++ List of more [useful resources and sample apps](https://github.com/h4cc/awesome-elixir)
++ If you want to know what's _next_ it's worth check out [What's Ahead for Elixir?](https://youtu.be/A60nxws_iVs) (53 mins)
 by **José Valim** (the creator of Elixir)
-
 + _Interview_ with **José Valim** (the creator of Elixir) on _why_ he made it!
 https://www.sitepoint.com/an-interview-with-elixir-creator-jose-valim/
 + What was "_wrong_" with just writing directly in Erlang? read:
 http://www.unlimitednovelty.com/2011/07/trouble-with-erlang-or-erlang-is-ghetto.tml
-
 + While Elixir by _itself_ is pretty _amazing_,
 where the language really shines is in the **Phoenix Web Framework**!!
-So once you know the basics of the language take a look at:
-https://github.com/dwyl/learn-phoenix-web-development
+So once you know the basics of the language [try learning Phoenix](https://github.com/dwyl/learn-phoenix-web-development).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Learn ![elixir logo](http://elixir-lang.org/images/logo/logo.png "Elixir Logo")
 
 ## Contents
-- [What?](#what)
 - [Why?](#why)
+- [What?](#what)
 - [How?](#how)
 - [Learn Elixir](#learn-elixir)
 - [Commands](#commands)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [Testing](#testing)
 - [Data Structures](#data-structures)
   - [Maps](#maps)
+- [Further Resources](#further-resources)
 
 
 ## *What*?
@@ -19,30 +20,15 @@
 [_"Elixir is a dynamic, functional language designed for building scalable and
  maintainable applications."_](http://elixir-lang.org/)
 
-### Video Resources
+### Video Introductions
 
-These videos introduce Elixir nicely:
+If you have the time, these videos give a nice contextual introduction into what Elixir is, what it's used for and how it works:
 
 <!-- note we should update this once we have
 made our *own* intro to Elixir vid! -->
 
 - Pete Broderick's [Intro to Elixir](https://youtu.be/lly-1UYmnFI) (41 mins)
-- Jessica Kerr's [Elixir Should Take Over the World](https://youtu.be/X25xOhntr6s)(58 mins)
-
-#### Further resources:
-
-- Then if you want to know what's _next_ it's worth watching [What's Ahead for Elixir?](https://youtu.be/A60nxws_iVs) (53 mins)
-by **José Valim** (the creator of Elixir)
-
-+ _Interview_ with **José Valim** (_the creator of Elixir_) on _why_ he made it!
-https://www.sitepoint.com/an-interview-with-elixir-creator-jose-valim/
-+ What was "_wrong_" with just writing directly in Erlang? read:
-http://www.unlimitednovelty.com/2011/07/trouble-with-erlang-or-erlang-is-ghetto.tml
-
-> While Elixir by _itself_ is pretty _amazing_,
-where the **_language_ really _shines_** is in the Phoenix Web Framework!!
-So _once_ you know the _basics_ of the _language_,
-https://github.com/dwyl/learn-phoenix-web-development
+- Jessica Kerr's [Elixir Should Take Over the World](https://youtu.be/X25xOhntr6s) (58 mins)
 
 ## *Why*?
 
@@ -892,3 +878,18 @@ to define a `function` (_and both have specific use-cases_),
 which is _way_ easier to explain to a _beginner_ than the JS approach.
 see:
 http://stackoverflow.com/questions/18011784/why-are-there-two-kinds-of-functions-in-elixir
+
+## Further resources:
+
+- Then if you want to know what's _next_ it's worth watching [What's Ahead for Elixir?](https://youtu.be/A60nxws_iVs) (53 mins)
+by **José Valim** (the creator of Elixir)
+
++ _Interview_ with **José Valim** (the creator of Elixir) on _why_ he made it!
+https://www.sitepoint.com/an-interview-with-elixir-creator-jose-valim/
++ What was "_wrong_" with just writing directly in Erlang? read:
+http://www.unlimitednovelty.com/2011/07/trouble-with-erlang-or-erlang-is-ghetto.tml
+
++ While Elixir by _itself_ is pretty _amazing_,
+where the language really shines is in the **Phoenix Web Framework**!!
+So once you know the basics of the language take a look at:
+https://github.com/dwyl/learn-phoenix-web-development

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - [Why?](#why)
 - [How?](#how)
 - [Learn Elixir](#learn-elixir)
-- [Commands]](#commands)
+- [Commands](#commands)
 - [Basic Types](#basic-types)
 - [Functions and Modules](#functions-and-modules)
 - [Generate an Elixir Project](#generating-your-first-elixir-project)
@@ -85,9 +85,7 @@ wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && sudo 
 + After installing Elixir you can open the interactive shell by typing `iex`.
 This allows you to type in any elixir expression and see the result in the terminal.
 
-+ Type in `h` followed by the `function` name at any time to see documentation information about any given built-in function and how to use it.
-
-E.g If you type `h round` into the (iex) terminal you should see
++ Type in `h` followed by the `function` name at any time to see documentation information about any given built-in function and how to use it. E.g If you type `h round` into the (iex) terminal you should see
 something like this:
 
 ![elixir-h](https://cloud.githubusercontent.com/assets/14013616/20860273/fc801b14-b96b-11e6-9b17-7e26666d5d94.png)
@@ -112,7 +110,9 @@ This section brings together the key information from Elixir's
 [Getting Started](http://elixir-lang.org/getting-started/basic-types.html)
 documentation and multiple other sources to further understanding.
 
-### *Working with numbers:*
+It will take you through some basic examples to practice using and familiarise yourself with Elixir's 7 basic types.
+
+### Numbers
 
 Try typing `1 + 2` into the terminal (after opening `iex`):
 ```elixir
@@ -155,7 +155,7 @@ iex> is_boolean(1)
 false
 ```
 
-### *Atoms*
+### Atoms
 
 Atoms are constants where their name is their own value
 (some other languages call these Symbols).
@@ -218,7 +218,7 @@ Thus, we can be sure that we will always have the lines returned to us
 and never a *nil* value (because it will throw an error).
 This becomes extremely useful when piping multiple methods together.
 
-### *Strings*
+### Strings
 
 Strings are surrounded by double quotes.
 
@@ -232,7 +232,7 @@ iex> IO.puts "Hello world"
 :ok
 ```
 
-### *Lists*
+### Lists
 
 Elixir uses square brackets to make a list.
 
@@ -256,7 +256,7 @@ iex> [1, true, 2, false, 3, true] -- [true, false]
 Lists are enumerable, the [Enum](https://hexdocs.pm/elixir/Enum.html)
 module provides lots of useful functions.
 
-### *Tuples*
+### Tuples
 
 Elixir uses curly brackets to make a tuple.
 
@@ -281,7 +281,7 @@ in the [Tuple](http://elixir-lang.org/docs/v1.0/elixir/Tuple.html) module.
 If you must treat your tuple as a list,
 then convert it using `Tuple.to_list(your_tuple)`
 
-### *Lists or Tuples?*
+### Lists or Tuples?
 
 A long story short, for large lists or tuples:
 + `Updating` a `list` (adding or removing elements) is **fast**

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ iex> :crypto.rand_bytes 3
 ```
 
 One popular use of atoms in Elixir is to use them as messages
-for pattern matching.
+for [pattern matching](https://en.wikipedia.org/wiki/Pattern_matching).
 Let's say you have a function which processes an `http` request.
 The outcome of this process is either going to be a success or an error.
 You could therefore use atoms to indicate whether

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - [Testing](#testing)
 - [Data Structures](#data-structures)
   - [Maps](#maps)
+- [Elixir Resources](#elixir-resources)
 - [Further Resources](#further-resources)
 
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ which are more difficult to manage)
 + **High reliability, availability and fault tolerance** (_because of Erlang_)
 means apps built with elixir are run in production for **years**
 without any "_downtime_"!
-+ **Zero-downtime deployment** is a _reality_ without any DevOps gymnastics!!!
 + Real-time web apps are "_easy_"
 (_or at least easier than many other languages!_) as **WebSockets & streaming** are baked-in
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ If you have the time, these videos give a nice contextual introduction into what
 <!-- note we should update this once we have
 made our *own* intro to Elixir vid! -->
 
-+ Code School's free [Try Elixir](https://www.codeschool.com/courses/try-elixir), 3 videos (25mins of videos plus exercises, totalling 90mins).
-- Pete Broderick's [Intro to Elixir](https://youtu.be/lly-1UYmnFI) (41 mins)
-- Jessica Kerr's [Elixir Should Take Over the World](https://youtu.be/X25xOhntr6s) (58 mins)
+- Code School's [Try Elixir](https://www.codeschool.com/courses/try-elixir), 3 videos (25mins :movie_camera: plus exercises, totalling 90mins). The 'Try' course is free (there is an extended paid for course).
+- Pete Broderick's [Intro to Elixir](https://youtu.be/lly-1UYmnFI) (41 mins :movie_camera:)
+- Jessica Kerr's [Elixir Should Take Over the World](https://youtu.be/X25xOhntr6s) (58 mins :movie_camera:)
+
+Not a video learner? Looking for a specific learning? https://elixirschool.com/ is an excellent, free, open-source resource that explains all things Elixir :book: :heart:.
 
 ## *Why*?
 

--- a/README.md
+++ b/README.md
@@ -588,7 +588,7 @@ This will create a new file in your file tree with the name of the file that
 you specified in the function. It will contain some odd characters for example this
 is what gets returned for our animals file:
 
-`�l   m   lionm   tigerm   gorillam   elephantm   monkeym   giraffej`
+�l\\&#0;&#0;&#0;&#6;m&#0;&#0;&#0;&#4;lionm&#0;&#0;&#0;&#5;tigerm&#0;&#0;&#0;&#7;gorillam&#0;&#0;&#0;&#8;elephantm&#0;&#0;&#0;&#6;monkeym&#0;&#0;&#0;&#7;giraffej
 
 #### Now let's write a function that will allow us to access that information again:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ made our *own* intro to Elixir vid! -->
 + **Scalability**
 + **Speed**
 + **Compiled** and run on the **Erlang VM** ("BEAM"). [(Renowned for efficiency)](http://stackoverflow.com/questions/16779162/what-kind-of-virtual-machine-is-beam-the-erlang-vm)
-+ Much better "_garbage collection_" than virtually any other VM
++ Much better ["garbage collection"](http://searchstorage.techtarget.com/definition/garbage-collection) than virtually any other VM
 + Many tiny processes (as opposed to "threads"
 which are more difficult to manage)
 + **Functional** language with [dynamic](https://www.sitepoint.com/typing-versus-dynamic-typing/) typing

--- a/README.md
+++ b/README.md
@@ -112,13 +112,13 @@ Elixir's 7 basic types:
 
 ### Numbers
 
-Try typing `1 + 2` into the terminal (after opening `iex`):
+Type `1 + 2` into the terminal (after opening `iex`):
 ```elixir
 iex> 1 + 2
 3
 ```
 
-Some more examples:
+More examples:
 
 ```elixir
 iex> 5 * 5

--- a/README.md
+++ b/README.md
@@ -275,13 +275,15 @@ iex> tuple_size(tuple)
 ```
 
 Tuples are [not enumerable](https://github.com/dwyl/learn-elixir/issues/39) and there are far fewer functions available
-in the [Tuple](http://elixir-lang.org/docs/v1.0/elixir/Tuple.html) module. You can reference tuple values by index but you cannot iterate over them.
+in the [Tuple](http://elixir-lang.org/docs/v1.0/elixir/Tuple.html) module. You can reference tuple values by index but [you cannot iterate over them](https://github.com/dwyl/learn-elixir/issues/39).
 If you must treat your tuple as a list,
 then convert it using `Tuple.to_list(your_tuple)`
 
 ### Lists or Tuples?
 
-A long story short, for large lists or tuples:
+If you need to iterate over the values use a list.
+
+When dealing with **large** lists or tuples:
 + `Updating` a `list` (adding or removing elements) is **fast**
 + `Updating` a `tuple` is **slow**
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,11 @@ something like this:
 
 ## Basic Types
 
-Elixir has 7 basic types:
+This section brings together the key information from Elixir's
+[Getting Started](http://elixir-lang.org/getting-started/basic-types.html)
+documentation and multiple other sources. It will take you through some examples to practice using and familiarise yourself with Elixir's 7 basic types.
+
+Elixir's 7 basic types:
 
 * `integers`
 * `floats`
@@ -105,12 +109,6 @@ Elixir has 7 basic types:
 * `strings`
 * `lists`
 * `tuples`
-
-This section brings together the key information from Elixir's
-[Getting Started](http://elixir-lang.org/getting-started/basic-types.html)
-documentation and multiple other sources to further understanding.
-
-It will take you through some basic examples to practice using and familiarise yourself with Elixir's 7 basic types.
 
 ### Numbers
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ made our *own* intro to Elixir vid! -->
 ## *Why*?
 
 ### Key Advantages
-+ Scalable
++ **Scalability**
++ **Speed**
 + **Compiled** and run on the **Erlang VM** ("BEAM"). [(Renowned for efficiency)](http://stackoverflow.com/questions/16779162/what-kind-of-virtual-machine-is-beam-the-erlang-vm)
 + Much better "_garbage collection_" than virtually any other VM
 + Many tiny processes (as opposed to "threads"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ If you have the time, these videos give a nice contextual introduction into what
 <!-- note we should update this once we have
 made our *own* intro to Elixir vid! -->
 
++ Code School's free [Try Elixir](https://www.codeschool.com/courses/try-elixir), 3 videos (25mins of videos plus exercises, totalling 90mins).
 - Pete Broderick's [Intro to Elixir](https://youtu.be/lly-1UYmnFI) (41 mins)
 - Jessica Kerr's [Elixir Should Take Over the World](https://youtu.be/X25xOhntr6s) (58 mins)
 
@@ -848,7 +849,6 @@ a current key-value pair inside the map, it cannot add a new key value pair.
 
 ## Elixir Resources
 
-+ An introduction to Elixir: https://www.codeschool.com/courses/try-elixir
 + Crash Course in Elixir: http://elixir-lang.org/crash-course.html
 + Explanation video of Pattern Matching in Elixir: http://worldwide.chat/
 + Sign up to: https://elixirweekly.net/ for regular (_relevant_) updates!

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Learn ![elixir logo](http://elixir-lang.org/images/logo/logo.png "Elixir Logo")
 
-Learn the Elixir _language_, designed to build dynamic, functional,
-scalable and maintainable web applications!
-
 ## Contents
 - [What?](#what)
 - [Why?](#why)

--- a/README.md
+++ b/README.md
@@ -32,31 +32,25 @@ made our *own* intro to Elixir vid! -->
 
 ## *Why*?
 
-Elixir is scalable, efficient, and fault-tolerant. Things *will* go wrong with
+### Key Advantages
++ Scalable
++ **Compiled** and run on the **Erlang VM** ("BEAM"). [(Renowned for efficiency)](http://stackoverflow.com/questions/16779162/what-kind-of-virtual-machine-is-beam-the-erlang-vm)
++ Much better "_garbage collection_" than virtually any other VM
++ Many tiny processes (as opposed to "threads"
+which are more difficult to manage)
++ **Functional** language with [dynamic](https://www.sitepoint.com/typing-versus-dynamic-typing/) typing
++ [Immutable data](https://benmccormick.org/2016/06/04/what-are-mutable-and-immutable-data-structures-2/) so ["state"](http://softwareengineering.stackexchange.com/questions/235558/what-is-state-mutable-state-and-immutable-state) is always **predictable**! <br />
+![image](https://cloud.githubusercontent.com/assets/194400/22413420/8a538bc2-e6af-11e6-80fd-209deb887820.png) <br />
++ **High reliability, availability and fault tolerance** (_because of Erlang_)
+means apps built with elixir are run in production for **years**
+without any "_downtime_"!
++ **Zero-downtime deployment** is a _reality_ without any DevOps gymnastics!!!
++ Real-time web apps are "_easy_"
+(_or at least easier than many other languages!_) as **WebSockets & streaming** are baked-in
+
+Things *will* go wrong with
 code, and Elixir provides supervisors which describe how to restart parts of
 your system when things don't go as planned.
-
-There are **_many_ reasons** to learn elixir
-and _use_ it for your next project!
-
-### Key Advantages
-
-+ Elixir is ***compiled*** and runs on the **Erlang VM** ("BEAM") which has been
-_demostrated_ to be ***incredibly efficient***! see:
-http://stackoverflow.com/questions/16779162/what-kind-of-virtual-machine-is-beam-the-erlang-vm
-+ Many tiny processes (_as opposed to "threads"
-which are more difficult to manage_)
-+ Much better "_garbage collection_" than virtually any other VM
-+ ***Functional*** language with _dynamic_ typing
-+ ***Immutable Data*** so "***State***" is ***always predictable***! <br />
-![image](https://cloud.githubusercontent.com/assets/194400/22413420/8a538bc2-e6af-11e6-80fd-209deb887820.png) <br />
-+ ***High Reliability, Availability and Fault Tolerance*** (_because of Erlang_)
-means apps built with elixir are run in production for ***Years***
-without any "_downtime_"!
-+ **WebSockets & Streaming** are baked-in
-so "**real-time**" web apps are "_easy_"
-(_or at least **easier** than many other languages!_)
-+ ***Zero-Downtime Deployment*** is a _reality_ without any DevOps gymnastics!!!
 
 ## *How*?
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Learn the Elixir _language_, designed to build dynamic, functional,
 scalable and maintainable web applications!
 
 ## Contents
-- [Why?](#why)
 - [What?](#what)
+- [Why?](#why)
 - [How?](#how)
 - [Handy Tips](#handy-tips)
 - [Basic Types](#basic-types)
@@ -15,6 +15,47 @@ scalable and maintainable web applications!
 - [Testing](#testing)
 - [Data Structures](#data-structures)
   - [Maps](#maps)
+
+## *What*?
+
+[_**"Elixir is a dynamic, functional language designed for building scalable and
+ maintainable applications."**_](http://elixir-lang.org/)
+
+### Video Introduction
+
+If you have a few minutes, probably the _easiest_ way to get _up-to-speed_
+with what Elixir is <br />
+(_and why we are **really excited** about it_),
+is Pete Broderick's ***Intro to Elixir***: https://youtu.be/lly-1UYmnFI
+
+  <!-- note we should update this once we have
+  made our *own* intro to Elixir vid! -->
+
+[![Pete Broderick - Intro to Elixir](https://cloud.githubusercontent.com/assets/194400/22414349/b41a24f0-e6b6-11e6-8e6e-6eb0c9ad188f.png)](https://youtu.be/lly-1UYmnFI "Click to Watch")
+
+Another _fantastic_ introduction is: Jessica Kerr's <br />
+  ***Elixir Should Take Over the World***: https://youtu.be/X25xOhntr6s
+
+[![Jessica Kerr - Elixir Should Take Over the World](https://cloud.githubusercontent.com/assets/194400/22414453/7dad1232-e6b7-11e6-8399-ccac3d1b9446.png)](https://youtu.be/X25xOhntr6s "Why Elixir should take over the World!")
+
+Then if you want to know what's _next_ it's worth watching  <br />
+***What's Ahead for Elixir?***
+by **José Valim** (_the creator of Elixir_): https://youtu.be/A60nxws_iVs
+
+[![José Valim - What's Ahead forElixir?](https://cloud.githubusercontent.com/assets/194400/22414818/8ef48248-e6b-11e6-8b24-6643fc180f72.png)](https://youtu.be/A60nxws_iVs "What's Ahead forElixir?")
+
+> While Elixir by _itself_ is pretty _amazing_,
+where the **_language_ really _shines_** is in the Phoenix Web Framework!!
+So _once_ you know the _basics_ of the _language_,
+https://github.com/dwyl/learn-phoenix-web-development
+
+
+### Background links:
+
++ _Interview_ with **José Valim** (_the creator of Elixir_) on _why_ he made it!
+https://www.sitepoint.com/an-interview-with-elixir-creator-jose-valim/
++ What was "_wrong_" with just writing directly in Erlang? read:
+http://www.unlimitednovelty.com/2011/07/trouble-with-erlang-or-erlang-is-ghetto.tml
 
 ## *Why*?
 
@@ -43,49 +84,6 @@ without any "_downtime_"!
 so "**real-time**" web apps are "_easy_"
 (_or at least **easier** than many other languages!_)
 + ***Zero-Downtime Deployment*** is a _reality_ without any DevOps gymnastics!!!
-
-
-## *What*?
-
-[_**"Elixir is a dynamic, functional language designed for building scalable and
- maintainable applications."**_](http://elixir-lang.org/)
-
-### Video Introduction
-
-If you have a few minutes, probably the _easiest_ way to get _up-to-speed_
-with what Elixir is <br />
-(_and why we are **really excited** about it_),
-is Pete Broderick's ***Intro to Elixir***: https://youtu.be/lly-1UYmnFI
-
-<!-- note we should update this once we have
-made our *own* intro to Elixir vid! -->
-
-[![Pete Broderick - Intro to Elixir](https://cloud.githubusercontent.com/assets/194400/22414349/b41a24f0-e6b6-11e6-8e6e-6eb0c9ad188f.png)](https://youtu.be/lly-1UYmnFI "Click to Watch")
-
-Another _fantastic_ introduction is: Jessica Kerr's <br />
-***Elixir Should Take Over the World***: https://youtu.be/X25xOhntr6s
-
-[![Jessica Kerr - Elixir Should Take Over the World](https://cloud.githubusercontent.com/assets/194400/22414453/7dad1232-e6b7-11e6-8399-ccac3d1b9446.png)](https://youtu.be/X25xOhntr6s "Why Elixir should take over the World!")
-
-Then if you want to know what's _next_ it's worth watching  <br />
-***What's Ahead for Elixir?***
-by **José Valim** (_the creator of Elixir_): https://youtu.be/A60nxws_iVs
-
-[![José Valim - What's Ahead for Elixir?](https://cloud.githubusercontent.com/assets/194400/22414818/8ef48248-e6ba-11e6-8b24-6643fc180f72.png)](https://youtu.be/A60nxws_iVs "What's Ahead for Elixir?")
-
-> While Elixir by _itself_ is pretty _amazing_,
-where the **_language_ really _shines_** is in the Phoenix Web Framework!!
-So _once_ you know the _basics_ of the _language_,
-https://github.com/dwyl/learn-phoenix-web-development
-
-
-### Background links:
-
-+ _Interview_ with **José Valim** (_the creator of Elixir_) on _why_ he made it!
-https://www.sitepoint.com/an-interview-with-elixir-creator-jose-valim/
-+ What was "_wrong_" with just writing directly in Erlang? read:
-http://www.unlimitednovelty.com/2011/07/trouble-with-erlang-or-erlang-is-ghetto.html
-
 
 ## *How*?
 

--- a/README.md
+++ b/README.md
@@ -846,8 +846,9 @@ iex> %{animals | name: "Max"}
 **NOTE:** Unlike the function method above, this syntax can only be used to UPDATE
 a current key-value pair inside the map, it cannot add a new key value pair.
 
-## Resources
+## Elixir Resources
 
++ An introduction to Elixir: https://www.codeschool.com/courses/try-elixir
 + Crash Course in Elixir: http://elixir-lang.org/crash-course.html
 + Explanation video of Pattern Matching in Elixir: http://worldwide.chat/
 + Sign up to: https://elixirweekly.net/ for regular (_relevant_) updates!

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ true
 This uses the inbuilt function `is_function` which checks to see if
 the parameter passed is a function and returns a bool.
 
-Anonymous functions are closures (_named_ functions are not)
+Anonymous functions are [closures](https://developer.mozilla.org/en/docs/Web/JavaScript/Closures) (_named_ functions are not)
 and as such they can access variables
 that are in scope when the function is defined.
 You can define a new anonymous function that uses the `add`
@@ -353,7 +353,7 @@ defmodule Math do
   end
 end
 ```
-In order to create your own modules in Elixir, use the `defmodule` macro,
+In order to create your own modules in Elixir, use the `defmodule` [macro](https://www.google.co.uk/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#q=what+is+a+macro&*),
 then use the `def` macro to define functions in that module.
 So in this case the module is `Math` and the function is `sum`.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 - [What?](#what)
 - [Why?](#why)
 - [How?](#how)
-- [Getting Started](#getting-started)
+- [Learn Elixir](#learn-elixir)
+- [Commands]](#commands)
 - [Basic Types](#basic-types)
 - [Functions and Modules](#functions-and-modules)
 - [Generate an Elixir Project](#generating-your-first-elixir-project)
@@ -77,28 +78,23 @@ wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && sudo 
 `sudo apt-get install esl-erlang`
 + **Install Elixir**: `sudo apt-get install elixir`
 
-## Getting Started
+## Learn Elixir
 
-### Interactive Terminal
-After installing Elixir you can open the interactive shell by typing `iex`.
-You can now type in any elixir expression and see the result in the terminal.
+## Commands
 
-### Function Documentation
-If you want to see some information about a built-in function you can
-just type `h` and the `function` name to get information on how to use it!
++ After installing Elixir you can open the interactive shell by typing `iex`.
+This allows you to type in any elixir expression and see the result in the terminal.
 
-Try typing `h round` into the (iex) terminal and you should see
++ Type in `h` followed by the `function` name at any time to see documentation information about any given built-in function and how to use it.
+
+E.g If you type `h round` into the (iex) terminal you should see
 something like this:
 
 ![elixir-h](https://cloud.githubusercontent.com/assets/14013616/20860273/fc801b14-b96b-11e6-9b17-7e26666d5d94.png)
 
-### Information about values
-If you want to see some information about a value in your code,
-type `i` followed by the value name:
++ Typing `i` followed by the value name will give you information about a value in your code:
 
 ![elixir-i](https://cloud.githubusercontent.com/assets/14013616/20860322/3c01d984-b96d-11e6-8cc4-a46c8657f5b4.png)
-
-
 
 ## Basic Types
 

--- a/README.md
+++ b/README.md
@@ -13,46 +13,36 @@
 - [Data Structures](#data-structures)
   - [Maps](#maps)
 
+
 ## *What*?
 
-[_**"Elixir is a dynamic, functional language designed for building scalable and
- maintainable applications."**_](http://elixir-lang.org/)
+[_"Elixir is a dynamic, functional language designed for building scalable and
+ maintainable applications."_](http://elixir-lang.org/)
 
-### Video Introduction
+### Video Resources
 
-If you have a few minutes, probably the _easiest_ way to get _up-to-speed_
-with what Elixir is <br />
-(_and why we are **really excited** about it_),
-is Pete Broderick's ***Intro to Elixir***: https://youtu.be/lly-1UYmnFI
+These videos introduce Elixir nicely:
 
-  <!-- note we should update this once we have
-  made our *own* intro to Elixir vid! -->
+<!-- note we should update this once we have
+made our *own* intro to Elixir vid! -->
 
-[![Pete Broderick - Intro to Elixir](https://cloud.githubusercontent.com/assets/194400/22414349/b41a24f0-e6b6-11e6-8e6e-6eb0c9ad188f.png)](https://youtu.be/lly-1UYmnFI "Click to Watch")
+- Pete Broderick's [Intro to Elixir](https://youtu.be/lly-1UYmnFI) (41 mins)
+- Jessica Kerr's [Elixir Should Take Over the World](https://youtu.be/X25xOhntr6s)(58 mins)
 
-Another _fantastic_ introduction is: Jessica Kerr's <br />
-  ***Elixir Should Take Over the World***: https://youtu.be/X25xOhntr6s
+#### Further resources:
 
-[![Jessica Kerr - Elixir Should Take Over the World](https://cloud.githubusercontent.com/assets/194400/22414453/7dad1232-e6b7-11e6-8399-ccac3d1b9446.png)](https://youtu.be/X25xOhntr6s "Why Elixir should take over the World!")
-
-Then if you want to know what's _next_ it's worth watching  <br />
-***What's Ahead for Elixir?***
-by **José Valim** (_the creator of Elixir_): https://youtu.be/A60nxws_iVs
-
-[![José Valim - What's Ahead forElixir?](https://cloud.githubusercontent.com/assets/194400/22414818/8ef48248-e6b-11e6-8b24-6643fc180f72.png)](https://youtu.be/A60nxws_iVs "What's Ahead forElixir?")
-
-> While Elixir by _itself_ is pretty _amazing_,
-where the **_language_ really _shines_** is in the Phoenix Web Framework!!
-So _once_ you know the _basics_ of the _language_,
-https://github.com/dwyl/learn-phoenix-web-development
-
-
-### Background links:
+- Then if you want to know what's _next_ it's worth watching [What's Ahead for Elixir?](https://youtu.be/A60nxws_iVs) (53 mins)
+by **José Valim** (the creator of Elixir)
 
 + _Interview_ with **José Valim** (_the creator of Elixir_) on _why_ he made it!
 https://www.sitepoint.com/an-interview-with-elixir-creator-jose-valim/
 + What was "_wrong_" with just writing directly in Erlang? read:
 http://www.unlimitednovelty.com/2011/07/trouble-with-erlang-or-erlang-is-ghetto.tml
+
+> While Elixir by _itself_ is pretty _amazing_,
+where the **_language_ really _shines_** is in the Phoenix Web Framework!!
+So _once_ you know the _basics_ of the _language_,
+https://github.com/dwyl/learn-phoenix-web-development
 
 ## *Why*?
 

--- a/README.md
+++ b/README.md
@@ -16,24 +16,6 @@
 - [Further Resources](#further-resources)
 
 
-## *What*?
-
-[_"Elixir is a dynamic, functional language designed for building scalable and
- maintainable applications."_](http://elixir-lang.org/)
-
-### Video Introductions
-
-If you have the time, these videos give a nice contextual introduction into what Elixir is, what it's used for and how it works:
-
-<!-- note we should update this once we have
-made our *own* intro to Elixir vid! -->
-
-- Code School's [Try Elixir](https://www.codeschool.com/courses/try-elixir), 3 videos (25mins :movie_camera: plus exercises, totalling 90mins). The 'Try' course is free (there is an extended paid for course).
-- Pete Broderick's [Intro to Elixir](https://youtu.be/lly-1UYmnFI) (41 mins :movie_camera:)
-- Jessica Kerr's [Elixir Should Take Over the World](https://youtu.be/X25xOhntr6s) (58 mins :movie_camera:)
-
-Not a video learner? Looking for a specific learning? https://elixirschool.com/ is an excellent, free, open-source resource that explains all things Elixir :book: :heart:.
-
 ## *Why*?
 
 ### Key Advantages
@@ -55,6 +37,24 @@ without any "_downtime_"!
 Things *will* go wrong with
 code, and Elixir provides supervisors which describe how to restart parts of
 your system when things don't go as planned.
+
+## *What*?
+
+[_"Elixir is a dynamic, functional language designed for building scalable and
+ maintainable applications."_](http://elixir-lang.org/)
+
+### Video Introductions
+
+If you have the time, these videos give a nice contextual introduction into what Elixir is, what it's used for and how it works:
+
+<!-- note we should update this once we have
+made our *own* intro to Elixir vid! -->
+
+- Code School's [Try Elixir](https://www.codeschool.com/courses/try-elixir), 3 videos (25mins :movie_camera: plus exercises, totalling 90mins). The 'Try' course is free (there is an extended paid for course).
+- Pete Broderick's [Intro to Elixir](https://youtu.be/lly-1UYmnFI) (41 mins :movie_camera:)
+- Jessica Kerr's [Elixir Should Take Over the World](https://youtu.be/X25xOhntr6s) (58 mins :movie_camera:)
+
+Not a video learner? Looking for a specific learning? https://elixirschool.com/ is an excellent, free, open-source resource that explains all things Elixir :book: :heart:.
 
 ## *How*?
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - [What?](#what)
 - [Why?](#why)
 - [How?](#how)
-- [Handy Tips](#handy-tips)
+- [Getting Started](#getting-started)
 - [Basic Types](#basic-types)
 - [Functions and Modules](#functions-and-modules)
 - [Generate an Elixir Project](#generating-your-first-elixir-project)
@@ -54,10 +54,12 @@ your system when things don't go as planned.
 
 ## *How*?
 
-How to install Elixir:
-http://elixir-lang.org/getting-started/introduction.html
+Before you learn Elixir as a language you will need to have it installed on your machine.
 
-### Installation basics:
+To do so you can go to
+http://elixir-lang.org/install.html or follow our guide here:
+
+### Installation:
 
 #### Mac:
 
@@ -65,17 +67,17 @@ http://elixir-lang.org/getting-started/introduction.html
 
 #### Ubuntu:
 
-+ **_Add_ the Erlang Solutions repo**:
++ **Add the Erlang Solutions repo**:
 
 ```
 wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && sudo dpkg -i erlang-solutions_1.0_all.deb
 ```
-+ _**Run**_: `sudo apt-get update`
-+ **_Install_ the Erlang/OTP platform and all of its applications**:
++ **Run**: `sudo apt-get update`
++ **Install the Erlang/OTP platform and all of its applications**:
 `sudo apt-get install esl-erlang`
-+ **_Install_ Elixir**: `sudo apt-get install elixir`
++ **Install Elixir**: `sudo apt-get install elixir`
 
-## Handy Tips
+## Getting Started
 
 ### Interactive Terminal
 After installing Elixir you can open the interactive shell by typing `iex`.

--- a/README.md
+++ b/README.md
@@ -251,8 +251,8 @@ iex> [1, true, 2, false, 3, true] -- [true, false]
 [1, 2, 3, true]
 ```
 
-Lists are enumerable, the [Enum](https://hexdocs.pm/elixir/Enum.html)
-module provides lots of useful functions.
+Lists are [enumerable](https://github.com/dwyl/learn-elixir/issues/39) and can use the [Enum](https://hexdocs.pm/elixir/Enum.html)
+module to perform iterative functions such as mapping.
 
 ### Tuples
 
@@ -274,8 +274,8 @@ iex> tuple_size(tuple)
 2
 ```
 
-Tuples are not enumerable and there are far fewer functions available
-in the [Tuple](http://elixir-lang.org/docs/v1.0/elixir/Tuple.html) module.
+Tuples are [not enumerable](https://github.com/dwyl/learn-elixir/issues/39) and there are far fewer functions available
+in the [Tuple](http://elixir-lang.org/docs/v1.0/elixir/Tuple.html) module. You can reference tuple values by index but you cannot iterate over them.
 If you must treat your tuple as a list,
 then convert it using `Tuple.to_list(your_tuple)`
 


### PR DESCRIPTION
- Reordered so 'What' comes before 'Why' for people who may not know what Elixir is before wanting to know why they should be using it.
- Removes repeating content and rephrases/ condenses existing content
- Removes video screenshots to try to shorten the length of the README
- Moves videos into 2 sections: introductory videos and extra resources ie. starter content, nice to have if you have the time content.
- Adds extra links for key terms that not all beginners may be familiar with e.g. dynamic typed language, immutable data, state.
- Sections out how to install and how to write elixir into clearer sections for better navigation by users
- Changes 'Handy Tips' section to 'Commands' to be more semantic