### PR TITLE
Update atom crypto example

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Atoms are also used to reference modules from Erlang libraries,
 including built-in ones.
 
 ```elixir
-iex> :crypto.rand_bytes 3
+iex> :crypto.strong_rand_bytes 3
 <<23, 104, 108>>
 ```
 


### PR DESCRIPTION
:crypto.rand_bytes has been depricated. Hence, replacing :crypto.rand_bytes with :crypto.strong_rand_bytes

ref => https://github.com/elixir-plug/plug/issues/392