### PR TITLE
adds link to homebrew package manager for mac installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ http://elixir-lang.org/install.html or follow our guide here:
 
 #### Mac:
 
+Using the [Homebrew](https://brew.sh/) package manager:
 `brew install elixir`
 
 #### Ubuntu:


### PR DESCRIPTION
Adds a link to Homebrew (https://brew.sh/) for those who don't already have it installed #96 